### PR TITLE
manager -> manager.ptr in ccall to fix null ptr issue

### DIFF
--- a/src/RSDD/RSDD.jl
+++ b/src/RSDD/RSDD.jl
@@ -251,7 +251,7 @@ Creates a BDD representing the constant true.
 Returns: BDD
 """
 function bdd_true(manager::Manager)
-    ptr = @rsdd_timed @ccall librsdd_path.bdd_true(manager::Manager)::Csize_t
+    ptr = @rsdd_timed @ccall librsdd_path.bdd_true(manager.ptr::ManagerPtr)::Csize_t
     BDD(manager, ptr)
 end
 
@@ -260,7 +260,7 @@ Creates a BDD representing the constant false.
 Returns: BDD
 """
 function bdd_false(manager::Manager)
-    ptr = @rsdd_timed @ccall librsdd_path.bdd_false(manager::Manager)::Csize_t
+    ptr = @rsdd_timed @ccall librsdd_path.bdd_false(manager.ptr::ManagerPtr)::Csize_t
     BDD(manager, ptr)
 end
 


### PR DESCRIPTION
## Summary of Changes

In the current codebase, we're incorrectly passing `manager::Manager` into several of the `@ccall` which actually expects `manager.ptr::ManagerPtr`. On MacOS, this didn't cause an error because `manager.ptr` happens to locate at the beginning of the struct, so referencing the outer struct yields the correct ptr. However, this behavior is very compiler-dependent, and on Ubuntu 24.04 LTS, these lines cause the downstream application to crash due to null ptr dereference.

This PR fixes the issue by replacing the two places where `manager::Manager` is used with `manager.ptr::ManagerPtr`